### PR TITLE
Blocks Till Maturity

### DIFF
--- a/src/client/scenes/channels/components/pending-force-channels-list-header.jsx
+++ b/src/client/scenes/channels/components/pending-force-channels-list-header.jsx
@@ -10,6 +10,6 @@ export const PendingForceChannelsListHeader = () => (
     <th>Closing tx id</th>
     <th>Limbo balance</th>
     <th>Maturity height</th>
-    <th>Blocks till maturity</th>
+    <th>Blocks til maturity</th>
   </tr>
 );

--- a/src/client/scenes/channels/components/pending-force-channels-list-item.jsx
+++ b/src/client/scenes/channels/components/pending-force-channels-list-item.jsx
@@ -27,7 +27,7 @@ export const PendingForceChannelsListItem = ({ channel }) => (
       <BtcAmount satoshi={channel.limbo_balance} />
     </td>
     <td>{channel.maturity_height}</td>
-    <td>{channel.blocks_till_maturity}</td>
+    <td>{channel.blocks_til_maturity}</td>
   </tr>
 );
 


### PR DESCRIPTION
There is a slight disagreement between the spelling of till in your code and LND.  Seems that LND spells it with one L, which is not correct.  LND requires more testing, I will make a pr there, but that will take more time, and in the meantime and if it gets rejected.