### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:alpine
+
+COPY . /lnd-explorer
+
+WORKDIR /lnd-explorer
+
+RUN npm install \
+&&  npm run build
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ LND_CERT_PATH - the path to tls.cert (default: OS specific default path for LND)
 LND_MACAROON_PATH - the path to the admin.macaroon file (default: OS specific default path for LND)
 LND_NO_MACAROONS - set to true to disable macaroons
 ```
+
+## Run with Docker
+
+Build the Dockerfile:
+
+```
+docker build . -t lnd-explorer
+```
+
+Run it, using the variables listed above to configure the application.  SERVER_HOST
+needs to be present to have the LND Explorer listen on all interfaces inside the container.
+
+```
+docker run -e LND_HOST=lightning -e SERVER_HOST=0.0.0.0 -v /full/path/to/.lnd:/root/.lnd/ -p 8000:8000 lnd-explorer
+```
+
+Then just navigate to http://localhost:8000


### PR DESCRIPTION
In this PR, we add Docker support.

Volume with the LND data must be mounted, and SERVER_HOST must be overridden.

I'm not sure the altangent user on Docker Hub is also you, but in any case I recommend setting up automatic builds from this repo (a 10 minute process) so users could skip building the container themselves and just run:

`docker run [snip] altangent/lnd-explorer`.